### PR TITLE
Fix EISDIR problem

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,8 @@
     "react-native-web": "~0.13.12"
   },
   "devDependencies": {
-    "@babel/core": "^7.9.0"
+    "@babel/core": "^7.9.0",
+    "@types/react-native": "~0.63.2"
   },
   "private": true,
   "name": "frontend",

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "compilerOptions": {},
+  "extends": "expo/tsconfig.base"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2059,6 +2059,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-native@~0.63.2":
+  version "0.63.52"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.63.52.tgz#449beb4a413ec0f2c172cbf676a95f5b0952adf4"
+  integrity sha512-sBXvvtJaIUSXQLDh9NZitx1KHkKUdBLZy34lFKJaIXtpHIh5OEbBXeyUTFBtFwjk/RD0tneAtUqsdhheZRzAzw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@^17.0.6":
   version "17.0.11"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.11.tgz#67fcd0ddbf5a0b083a0f94e926c7d63f3b836451"
@@ -3926,7 +3933,7 @@ eslint-plugin-react-hooks@^4.2.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz#8c229c268d468956334c943bb45fc860280f5556"
   integrity sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==
 
-eslint-plugin-react@7.24.0, eslint-plugin-react@^7.23.1, eslint-plugin-react@^7.23.2:
+eslint-plugin-react@^7.23.1, eslint-plugin-react@^7.23.2:
   version "7.24.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.24.0.tgz#eadedfa351a6f36b490aa17f4fa9b14e842b9eb4"
   integrity sha512-KJJIx2SYx7PBx3ONe/mEeMz4YE0Lcr7feJTCMyyKb/341NcjuAgim3Acgan89GfPv7nxXK2+0slu0CWXYM4x+Q==
@@ -3944,7 +3951,7 @@ eslint-plugin-react@7.24.0, eslint-plugin-react@^7.23.1, eslint-plugin-react@^7.
     resolve "^2.0.0-next.3"
     string.prototype.matchall "^4.0.5"
 
-eslint-plugin-testing-library@4.6.0, eslint-plugin-testing-library@^4.0.1:
+eslint-plugin-testing-library@^4.0.1:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-4.6.0.tgz#f08f60fdc016952cf65a3fc5a467348c9d9590da"
   integrity sha512-s1ewfnLs8BF+apZ0kIvZhe5ejDgLtawIhc5Mec4aTJGQdrse6tP/RffWicwPENWh8SpmbetcklSR+14/jsnvGw==


### PR DESCRIPTION
I was getting this error when I ran `yarn start` / `expo start`

```bash
Error: EISDIR: illegal operation on a directory, read
    at Object.readSync (node:fs:721:3)
    at tryReadSync (node:fs:431:20)
    at Object.readFileSync (node:fs:477:19)
    at UnableToResolveError.buildCodeFrameMessage (/Users/k/p/my-coffee-mobile-app/frontend/node_modules/metro/src/node-haste/DependencyGraph/ModuleResolution.js:304:17)
    at new UnableToResolveError (/Users/k/p/my-coffee-mobile-app/frontend/node_modules/metro/src/node-haste/DependencyGraph/ModuleResolution.js:290:35)
    at ModuleResolver.resolveDependency (/Users/k/p/my-coffee-mobile-app/frontend/node_modules/metro/src/node-haste/DependencyGraph/ModuleResolution.js:168:15)
    at DependencyGraph.resolveDependency (/Users/k/p/my-coffee-mobile-app/frontend/node_modules/metro/src/node-haste/DependencyGraph.js:353:43)
    at /Users/k/p/my-coffee-mobile-app/frontend/node_modules/metro/src/lib/transformHelpers.js:271:42
    at Server.<anonymous> (/Users/k/p/my-coffee-mobile-app/frontend/node_modules/metro/src/Server.js:842:41)
    at Generator.next (<anonymous>)
    at asyncGeneratorStep (/Users/k/p/my-coffee-mobile-app/frontend/node_modules/metro/src/Server.js:99:24)
    at _next (/Users/k/p/my-coffee-mobile-app/frontend/node_modules/metro/src/Server.js:119:9)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
› Stopped server
✨  Done in 114.40s.
```

Seemed to have something to do with TypeScript:

https://github.com/ds300/react-native-typescript-transformer/issues/28

So I just followed the TypeScript guide here:

https://docs.expo.io/guides/typescript/